### PR TITLE
docs: align pytest command with current project layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ OpenMOSS/
 |   +-- local-web-search/           # Local gateway web search Skill ⚙️
 |
 |-- rules/                          # Global rule templates
-|-- tests/                          # Test cases
+|-- tests/                          # Test cases (optional, add when contributing tests)
 |-- docs/                           # Design documents
 |-- config.example.yaml             # Config file template
 |-- requirements.txt                # Python dependencies
@@ -496,7 +496,7 @@ pip install -r requirements.txt
 python -m uvicorn app.main:app --host 0.0.0.0 --port 6565 --reload
 
 # Run tests
-python -m pytest tests/
+python -m pytest
 ```
 
 ### Frontend Development

--- a/README_CN.md
+++ b/README_CN.md
@@ -273,7 +273,7 @@ OpenMOSS/
 |   +-- local-web-search/           # 本地网关 Web 搜索 Skill ⚙️
 |
 |-- rules/                          # 全局规则模板
-|-- tests/                          # 测试用例
+|-- tests/                          # 测试用例（可选，贡献测试时添加）
 |-- docs/                           # 设计文档
 |-- config.example.yaml             # 配置文件模板
 |-- requirements.txt                # Python 依赖
@@ -520,7 +520,7 @@ pip install -r requirements.txt
 python -m uvicorn app.main:app --host 0.0.0.0 --port 6565 --reload
 
 # 运行测试
-python -m pytest tests/
+python -m pytest
 ```
 
 ### 前端开发


### PR DESCRIPTION
## What changed
- Updated the backend development testing command in both `README.md` and `README_CN.md` from `python -m pytest tests/` to `python -m pytest`.
- Marked the `tests/` directory as optional in the project structure sections of both READMEs.

## Why
- The current repository layout does not include a committed `tests/` directory, so `python -m pytest tests/` is misleading and can fail due to a missing path.
- Using `python -m pytest` matches standard pytest discovery and keeps the setup instructions accurate for current and future contributors.

## Testing
- Command run: `python -m pytest`
- Tests: not run (no tests found)
