### PR TITLE
feat: add agent rename and description update via admin API and WebUI

### DIFF
--- a/app/routers/admin_agents.py
+++ b/app/routers/admin_agents.py
@@ -18,6 +18,7 @@ from app.schemas.admin_agent import (
     AdminAgentResetKeyResponse,
     AdminAgentScoreLogPageResponse,
     AdminAgentStatusUpdateRequest,
+    AdminAgentUpdateRequest,
     AdminAgentWriteResponse,
 )
 from app.services import admin_agent_query_service, agent_service
@@ -183,6 +184,36 @@ async def list_admin_agent_request_logs(
         )
     except Exception as exc:
         _raise_admin_agent_query_error(exc)
+@router.put(
+    "/agents/{agent_id}",
+    response_model=AdminAgentWriteResponse,
+    summary="管理端更新 Agent 名称/描述",
+)
+async def update_admin_agent_profile(
+    agent_id: str,
+    req: AdminAgentUpdateRequest,
+    _: bool = Depends(verify_admin),
+    db: Session = Depends(get_db),
+):
+    """管理员更新 Agent 的名称或描述"""
+    try:
+        agent = agent_service.update_agent_profile(
+            db,
+            agent_id,
+            name=req.name,
+            description=req.description,
+        )
+    except Exception as exc:
+        _raise_admin_agent_write_error(exc)
+    else:
+        return AdminAgentWriteResponse(
+            id=agent.id,
+            name=agent.name,
+            role=agent.role,
+            description=agent.description,
+            status=agent.status,
+            total_score=agent.total_score,
+        )
 
 
 @router.put(

--- a/app/schemas/admin_agent.py
+++ b/app/schemas/admin_agent.py
@@ -124,6 +124,11 @@ class AdminAgentStatusUpdateRequest(BaseModel):
     status: AgentStatus = Field(..., description="状态")
 
 
+class AdminAgentUpdateRequest(BaseModel):
+    name: Optional[str] = Field(None, description="Agent 名称", max_length=100)
+    description: Optional[str] = Field(None, description="职责简要")
+
+
 class AdminAgentWriteResponse(BaseModel):
     id: str
     name: str

--- a/app/services/agent_service.py
+++ b/app/services/agent_service.py
@@ -67,6 +67,30 @@ def list_agents(db: Session, role: str = None, status: str = None) -> list:
 def get_agent_by_id(db: Session, agent_id: str) -> Agent:
     """根据 ID 获取 Agent"""
     return db.query(Agent).filter(Agent.id == agent_id).first()
+def update_agent_profile(
+    db: Session,
+    agent_id: str,
+    name: str | None = None,
+    description: str | None = None,
+) -> Agent:
+    """更新 Agent 名称/描述"""
+    agent = db.query(Agent).filter(Agent.id == agent_id).first()
+    if not agent:
+        raise ValueError(f"Agent {agent_id} 不存在")
+
+    if name:
+        # 防重复名
+        existing = db.query(Agent).filter(Agent.name == name, Agent.id != agent_id).first()
+        if existing:
+            raise ValueError(f"名称 '{name}' 已被注册")
+        agent.name = name
+
+    if description is not None:
+        agent.description = description
+
+    db.commit()
+    db.refresh(agent)
+    return agent
 
 
 def update_agent_status(db: Session, agent_id: str, status: str) -> Agent:

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -189,6 +189,10 @@ export const adminAgentApi = {
     api.get<AdminPageResponse<AdminAgentItem>>('/admin/agents', { params }),
   get: (agentId: string) =>
     api.get<AdminAgentDetail>(`/admin/agents/${agentId}`),
+  updateProfile: (
+    agentId: string,
+    data: { name?: string; description?: string },
+  ) => api.put(`/admin/agents/${agentId}`, data),
   updateStatus: (agentId: string, status: string) =>
     api.put(`/admin/agents/${agentId}/status`, { status }),
   scoreLogs: (agentId: string, params?: { page?: number; page_size?: number; sub_task_id?: string; sort_order?: string }) =>

--- a/webui/src/views/AgentsView.vue
+++ b/webui/src/views/AgentsView.vue
@@ -25,6 +25,7 @@ import {
     KeyRound,
     Copy,
     Check,
+    Pencil,
 } from 'lucide-vue-next'
 
 // ─── 状态 ───
@@ -234,6 +235,43 @@ const showNewKeyDialog = ref(false)
 const newApiKey = ref('')
 const resettingKey = ref(false)
 const keyCopied = ref(false)
+
+// 改名/改描述
+const showEditDialog = ref(false)
+const editName = ref('')
+const editDescription = ref('')
+const editError = ref('')
+const savingEdit = ref(false)
+
+function openEditDialog() {
+    if (!selectedAgent.value) return
+    editName.value = selectedAgent.value.name
+    editDescription.value = selectedAgent.value.description ?? ''
+    editError.value = ''
+    showEditDialog.value = true
+}
+
+async function handleSaveEdit() {
+    if (!selectedAgentId.value) return
+    const name = editName.value.trim()
+    if (!name) { editError.value = '名称不能为空'; return }
+    savingEdit.value = true
+    editError.value = ''
+    try {
+        await adminAgentApi.updateProfile(selectedAgentId.value, {
+            name,
+            description: editDescription.value,
+        })
+        showEditDialog.value = false
+        void loadAgentDetail(selectedAgentId.value)
+        void loadAgents()
+    } catch (err: unknown) {
+        const msg = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+        editError.value = msg ?? '保存失败，请重试'
+    } finally {
+        savingEdit.value = false
+    }
+}
 
 async function handleResetKey() {
     if (!selectedAgentId.value) return
@@ -521,6 +559,10 @@ async function copyNewKey() {
                                 操作
                             </div>
                             <div class="flex flex-wrap gap-2">
+                                <Button variant="outline" size="sm" class="gap-1.5" @click="openEditDialog">
+                                    <Pencil class="h-3.5 w-3.5" />
+                                    编辑名称/描述
+                                </Button>
                                 <Button variant="outline" size="sm"
                                     class="gap-1.5 text-rose-600 hover:text-rose-700 hover:bg-rose-50"
                                     @click="showResetKeyConfirm = true">
@@ -542,6 +584,40 @@ async function copyNewKey() {
             </div>
         </div>
     </TooltipProvider>
+
+    <!-- 编辑名称/描述弹窗 -->
+    <Teleport to="body">
+        <Transition name="fade">
+            <div v-if="showEditDialog" class="fixed inset-0 z-50 flex items-center justify-center">
+                <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" @click="showEditDialog = false" />
+                <div
+                    class="relative z-10 w-full max-w-sm rounded-xl border bg-background p-6 shadow-2xl animate-in fade-in zoom-in-95 duration-200">
+                    <h2 class="text-lg font-semibold mb-4">编辑 Agent 信息</h2>
+                    <div class="space-y-3">
+                        <div>
+                            <label class="text-xs text-muted-foreground mb-1 block">名称</label>
+                            <Input v-model="editName" placeholder="Agent 名称" maxlength="100" />
+                        </div>
+                        <div>
+                            <label class="text-xs text-muted-foreground mb-1 block">描述</label>
+                            <textarea v-model="editDescription" placeholder="职责简要（可选）"
+                                class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+                                rows="3" />
+                        </div>
+                        <p v-if="editError" class="text-xs text-rose-500">{{ editError }}</p>
+                    </div>
+                    <div class="mt-5 flex gap-3">
+                        <Button variant="outline" class="flex-1" :disabled="savingEdit"
+                            @click="showEditDialog = false">取消</Button>
+                        <Button class="flex-1" :disabled="savingEdit" @click="handleSaveEdit">
+                            <Loader2 v-if="savingEdit" class="h-4 w-4 animate-spin mr-1" />
+                            保存
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </Transition>
+    </Teleport>
 
     <!-- 重置 API Key 确认弹窗 -->
     <Teleport to="body">


### PR DESCRIPTION
## 功能说明

新增管理端修改 Agent 名称和描述的功能，只能通过 WebUI 手动操作。

## 改动内容

- 新增 `PUT /api/admin/agents/{id}` 接口（需管理员 Token）
- 新增 `update_agent_profile()` 服务方法，含重名校验
- 新增 `AdminAgentUpdateRequest` schema（name/description 均为可选字段）
- 前端 API 客户端新增 `adminAgentApi.updateProfile()`
- Agents 页面操作区新增「编辑名称/描述」弹窗，支持 loading 状态和错误提示